### PR TITLE
Improve English prompts and preview labels

### DIFF
--- a/demo/KeyleFinder.py
+++ b/demo/KeyleFinder.py
@@ -95,20 +95,20 @@ class KeyleFinder:
             cv2.drawMarker(preview, center, (255, 0, 0), cv2.MARKER_CROSS, 20, 2)
 
             if label is not None:
-                x = int(np.min(dst_points[:, 0]))
-                y = int(np.min(dst_points[:, 1])) - 10
-                y = max(y, 0)
+                # Always display the path label in the upper left corner so it
+                # does not overlap the previewed image. Long paths will wrap to
+                # the next line automatically.
                 self._draw_multiline_text(
                     preview,
                     label,
-                    (x, y),
+                    (10, 30),
                     cv2.FONT_HERSHEY_SIMPLEX,
                     0.5,
                     (0, 0, 255),
                     1,
                 )
         else:
-            text = "未成功匹配" if label is None else f"未成功匹配: {label}"
+            text = "Match failed" if label is None else f"Match failed: {label}"
             self._draw_multiline_text(
                 preview,
                 text,

--- a/demo/SubImgMatch.py
+++ b/demo/SubImgMatch.py
@@ -7,4 +7,9 @@ if __name__ == "__main__":
     matcher = ImageMatcher(big_image_path)
     top_left, bottom_right = matcher.match(single_image_path, show_preview=True)
     # print("找到图像在大图中的位置：左上角坐标{}, 右下角坐标{}".format(top_left, bottom_right))
-    print("找到图{}在{}中，左上角坐标{}，右下角坐标{}".format(os.path.basename(single_image_path), os.path.basename(big_image_path), top_left, bottom_right))   
+    print("Found image {} in {}, top-left {}, bottom-right {}".format(
+        os.path.basename(single_image_path),
+        os.path.basename(big_image_path),
+        top_left,
+        bottom_right,
+    ))

--- a/netTset/Program.cs
+++ b/netTset/Program.cs
@@ -8,7 +8,7 @@ using Newtonsoft;
 
 var netHelper = new NetHelper();
 
-Console.WriteLine("输入端口(先启动KeyleKitService.py脚本)：");
+Console.WriteLine("Enter port (start KeyleKitService.py first):");
 var port = Console.ReadLine();
 
 await netHelper.ConnectAsync("127.0.0.1", int.Parse(port));
@@ -18,7 +18,7 @@ var ta = Task.Run(netHelper.ReceiveMessageAsync, cts.Token);
 
 while (true)
 {
-    Console.WriteLine("输入任意消息回车发送，输入exit退出：");
+    Console.WriteLine("Type a message and press Enter to send, type exit to quit:");
     var content = Console.ReadLine();
 
     // 发送消息给服务器
@@ -43,7 +43,7 @@ while (true)
 }
 // 关闭连接
 netHelper.Close();
-Console.ReadLine(); // 等待用户按下回车键退出
+Console.ReadLine(); // Press Enter to exit
 
 
 public class NetHelper
@@ -62,11 +62,11 @@ public class NetHelper
         {
             await client.ConnectAsync(ipAddress, port);
             stream = client.GetStream();
-            Console.WriteLine("连接到服务器成功");
+            Console.WriteLine("Connected to server");
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"无法连接到服务器: {ex.Message}");
+            Console.WriteLine($"Failed to connect to server: {ex.Message}");
         }
     }
 
@@ -79,7 +79,7 @@ public class NetHelper
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"发送消息失败: {ex.Message}");
+            Console.WriteLine($"Failed to send message: {ex.Message}");
         }
     }
 
@@ -91,7 +91,7 @@ public class NetHelper
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"发送消息失败: {ex.Message}");
+            Console.WriteLine($"Failed to send message: {ex.Message}");
         }
     }
 
@@ -102,11 +102,11 @@ public class NetHelper
             byte[] data = new byte[1024 * 1024];
             int bytes = await stream.ReadAsync(data, 0, data.Length);
             string receivedMessage = Encoding.UTF8.GetString(data, 0, bytes);
-            Console.WriteLine("服务器回复：" + receivedMessage);
+            Console.WriteLine("Server reply: " + receivedMessage);
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"接收消息失败: {ex.Message}");
+            Console.WriteLine($"Failed to receive message: {ex.Message}");
             return null;
         }
 
@@ -117,6 +117,6 @@ public class NetHelper
     {
         stream.Close();
         client.Close();
-        Console.WriteLine("连接已关闭");
+        Console.WriteLine("Connection closed");
     }
 }

--- a/project/KeyleKitService.py
+++ b/project/KeyleKitService.py
@@ -170,8 +170,8 @@ class KeyleKitService:
         sub_x = parent_x + offset_x
         sub_y = parent_y + offset_y
 
-        # 打印偏移值
-        print("偏移值：", offset_x, offset_y)
+        # Print the offset values for debugging
+        print("Offset:", offset_x, offset_y)
         # self.send_text.delete("1.0", "end")
         self.send_text.insert(tk.END, f'{offset_x}|{offset_y}\n')
         self.send_message()


### PR DESCRIPTION
## Summary
- show preview labels in the upper left corner
- translate match failure message to English
- update image matching script output text
- translate C# console prompts
- clarify offset log output

## Testing
- `python3 -m py_compile demo/KeyleFinder.py demo/SubImgMatch.py project/KeyleKitService.py`

------
https://chatgpt.com/codex/tasks/task_e_68401dee18a08323912033a2a3aacb93