### PR TITLE
Fix window minimize behavior in locator

### DIFF
--- a/gui_locator.py
+++ b/gui_locator.py
@@ -76,7 +76,9 @@ class App(tk.Tk):
         self.protocol('WM_DELETE_WINDOW', self.on_close)
 
     def load_image(self):
-        self.withdraw()
+        # Minimize to taskbar instead of fully hiding so the user can
+        # restore the window manually if needed.
+        self.iconify()
         time.sleep(0.2)
         screenshot = pyautogui.screenshot()
         ScreenCropper(self, screenshot, self.on_crop_done)
@@ -106,7 +108,8 @@ class App(tk.Tk):
             finder = KeyleFinderModule(tmp.name)
             result = finder.locate(self.sub_img_path, debug=True)
         os.unlink(tmp.name)
-        self.deiconify()
+        # Keep the window minimized after locating so the user can
+        # continue working without interruption.
         if result.get('status') == 0:
             tl = result['top_left']
             br = result['bottom_right']


### PR DESCRIPTION
## Summary
- minimize main GUI to taskbar during screenshot cropping
- keep window minimized after hotkey search to avoid showing it again

## Testing
- `python KeyleFinderModuleTest.py`

------
https://chatgpt.com/codex/tasks/task_e_68415fdb20a083238b3d5784ed5d6a76